### PR TITLE
Remove the conflicting entry from the ~/.ssh/known_hosts

### DIFF
--- a/devstack-setup.yml
+++ b/devstack-setup.yml
@@ -65,6 +65,12 @@
                 groups=clouddev
                 ansible_ssh_private_key_file="{{ private_key_file }}"
                 ansible_ssh_user=centos
+    - name: Remove the conflicting entry from the ~/.ssh/known_hosts
+      when: devstack_host_vm.openstack.public_v4 is defined
+      lineinfile:
+        path: ~/.ssh/known_hosts
+        state: absent
+        regexp: "{{ devstack_host_vm.openstack.public_v4 }} *"
     - name: Create local login script
       template: src=login.sh
                 dest=.


### PR DESCRIPTION
This will save the user the effort of removing the entry manually at
every setup.

Signed-off-by: Rishabh Dave <ridave@redhat.com>